### PR TITLE
Ajout du YAML linter

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,12 @@
+---
+name: YAML Linter
+on: [push, pull_request]
+jobs:
+  yaml-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: yaml-lint
+        uses: ibiqlik/action-yamllint@v1
+        with:
+          config_file: yaml-lint.yml

--- a/yaml-lint.yml
+++ b/yaml-lint.yml
@@ -1,0 +1,7 @@
+---
+extends: default
+
+rules:
+  line-length:
+    max: 100
+    level: warning


### PR DESCRIPTION
Désormais ce test sera nécessaire pour chaque commit sur Cardinal afin d'éviter tout problème à l'avenir.