### PR TITLE
Renommage de l'Action du Merge Bot

### DIFF
--- a/.github/workflows/merge-bot.yml
+++ b/.github/workflows/merge-bot.yml
@@ -1,4 +1,4 @@
-name: Merge Bot
+name: Merge-bot
 
 on:
   pull_request:


### PR DESCRIPTION
Le message Discord dit "Merge success on pull request #N", ce qui peut porter à confusion donc changer le nom de "Merge Bot" (dont seul "Merge" est affiché) en "Merge-bot"